### PR TITLE
fix to allow no arguments

### DIFF
--- a/release-note-script/src/main/java/MergeReleaseNotes.java
+++ b/release-note-script/src/main/java/MergeReleaseNotes.java
@@ -38,7 +38,7 @@ public class MergeReleaseNotes {
   public static void main(String... args) throws Exception {
 
     if (args.length > 0) {
-      if (args[0].equalsIgnoreCase("-h") || args[0].equalsIgnoreCase("--help")) {
+      if (args[0].equals("-h") || args[0].equals("--help")) {
         System.err.printf("Usage: java %s.java%n", MergeReleaseNotes.class.getSimpleName());
         System.exit(0);
       }

--- a/release-note-script/src/main/java/MergeReleaseNotes.java
+++ b/release-note-script/src/main/java/MergeReleaseNotes.java
@@ -36,10 +36,12 @@ public class MergeReleaseNotes {
       new EnumMap<>(Edition.class);
 
   public static void main(String... args) throws Exception {
-    if (args.length == 0) {
-      System.err.printf(
-          "Usage: java %s.java scalardb.md cluster.md graphql.md sql.md%n",
-          MergeReleaseNotes.class.getSimpleName());
+
+    if (args.length > 0) {
+      if (args[0].equalsIgnoreCase("-h") || args[0].equalsIgnoreCase("--help")) {
+        System.err.printf("Usage: java %s.java%n", MergeReleaseNotes.class.getSimpleName());
+        System.exit(0);
+      }
     }
 
     MergeReleaseNotes mergeReleaseNotes = new MergeReleaseNotes();


### PR DESCRIPTION
## Description

This PR fixes a bug where the `MergeReleaseNotes.java` script required at least one argument when in fact no argument was required.

## Related issues and/or PRs

N/A

## Changes made

- Removed check for the number of arguments so that the script can be executed with no arguments.
- Added `-h` `--help` options to display the usage of the script

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A