### PR TITLE
added backward-incompatible category and remove documentation category

### DIFF
--- a/release-note-script/src/main/java/MergeReleaseNotes.java
+++ b/release-note-script/src/main/java/MergeReleaseNotes.java
@@ -185,7 +185,7 @@ public class MergeReleaseNotes {
   }
 
   enum Category {
-    BACKWARD_INCOMPATIBLE("Backward incompatibles"),
+    BACKWARD_INCOMPATIBLE("Backward incompatible changes"),
     ENHANCEMENT("Enhancements"),
     IMPROVEMENT("Improvements"),
     BUGFIX("Bug fixes"),

--- a/release-note-script/src/main/java/MergeReleaseNotes.java
+++ b/release-note-script/src/main/java/MergeReleaseNotes.java
@@ -185,10 +185,10 @@ public class MergeReleaseNotes {
   }
 
   enum Category {
+    BACKWARD_INCOMPATIBLE("Backward incompatibles"),
     ENHANCEMENT("Enhancements"),
     IMPROVEMENT("Improvements"),
     BUGFIX("Bug fixes"),
-    DOCUMENTATION("Documentation"),
     MISCELLANEOUS("Miscellaneous");
 
     private final String displayName;
@@ -203,7 +203,7 @@ public class MergeReleaseNotes {
 
     public static Category getByDisplayName(String displayName) {
       return Arrays.stream(Category.values())
-          .filter(v -> v.displayName.equals(displayName))
+          .filter(v -> v.getDisplayName().equals(displayName))
           .findFirst()
           .orElseThrow(() -> new IllegalArgumentException("Invalid displayName: " + displayName));
     }

--- a/release-note-script/src/main/java/ReleaseNoteCreation.java
+++ b/release-note-script/src/main/java/ReleaseNoteCreation.java
@@ -219,7 +219,7 @@ public class ReleaseNoteCreation {
   }
 
   public enum Category {
-    BACKWARD_INCOMPATIBLE("Backward incompatibles", "backward-incompatible"),
+    BACKWARD_INCOMPATIBLE("Backward incompatible changes", "backward-incompatible"),
     ENHANCEMENT("Enhancements", "enhancement"),
     IMPROVEMENT("Improvements", "improvement"),
     BUGFIX("Bug fixes", "bugfix"),

--- a/release-note-script/src/main/java/ReleaseNoteCreation.java
+++ b/release-note-script/src/main/java/ReleaseNoteCreation.java
@@ -219,30 +219,33 @@ public class ReleaseNoteCreation {
   }
 
   public enum Category {
-    ENHANCEMENT("Enhancements"),
-    IMPROVEMENT("Improvements"),
-    BUGFIX("Bug fixes"),
-    DOCUMENTATION("Documentation"),
-    MISCELLANEOUS("Miscellaneous");
+    BACKWARD_INCOMPATIBLE("Backward incompatibles", "backward-incompatible"),
+    ENHANCEMENT("Enhancements", "enhancement"),
+    IMPROVEMENT("Improvements", "improvement"),
+    BUGFIX("Bug fixes", "bugfix"),
+    MISCELLANEOUS("Miscellaneous", "miscellaneous");
 
     private final String displayName;
+    private final String label;
 
-    Category(String displayName) {
+    Category(String displayName, String label) {
       this.displayName = displayName;
+      this.label = label;
     }
 
     public String getDisplayName() {
       return this.displayName;
     }
 
-    public static Category fromDisplayName(String name) {
+    public String getLabel() {
+      return this.label;
+    }
+
+    public static Category fromLabel(String label) {
       return Arrays.stream(Category.values())
-          .filter(
-              v ->
-                  v.name()
-                      .equalsIgnoreCase(name)) // v.name() is needed to compare with a label of a PR
+          .filter(v -> v.getLabel().equalsIgnoreCase(label))
           .findFirst()
-          .orElseThrow(() -> new IllegalArgumentException("Invalid name: " + name));
+          .orElseThrow(() -> new IllegalArgumentException("Invalid label: " + label));
     }
   }
 
@@ -322,7 +325,7 @@ public class ReleaseNoteCreation {
 
       String line;
       while ((line = br.readLine()) != null) {
-        if (isValidCategory(line)) return Category.fromDisplayName(line);
+        if (isValidCategory(line)) return Category.fromLabel(line);
       }
       return Category.MISCELLANEOUS;
     }
@@ -343,7 +346,7 @@ public class ReleaseNoteCreation {
 
     private boolean isValidCategory(String category) {
       return Arrays.stream(Category.values())
-          .anyMatch(target -> target.name().equalsIgnoreCase(category));
+          .anyMatch(target -> target.getLabel().equalsIgnoreCase(category));
     }
   }
 }

--- a/release-note-script/src/test/java/ReleaseNoteCreationTest.java
+++ b/release-note-script/src/test/java/ReleaseNoteCreationTest.java
@@ -214,7 +214,7 @@ public class ReleaseNoteCreationTest {
 
     String expected =
         "## Summary\n\n"
-            + "## Backward incompatibles\n"
+            + "## Backward incompatible changes\n"
             + "- A backward-incompatible text 1. (#7)\n"
             + "- A backward-incompatible text 2. (#8)\n\n"
             + "## Enhancements\n"

--- a/release-note-script/src/test/java/ReleaseNoteCreationTest.java
+++ b/release-note-script/src/test/java/ReleaseNoteCreationTest.java
@@ -104,12 +104,15 @@ public class ReleaseNoteCreationTest {
         "4",
         ReleaseNoteCreation.Category.BUGFIX,
         "Same as #1\nAdditional comment 2.");
+    addMockBehaviourToGitHubContext(
+        ghContextMock, "5", ReleaseNoteCreation.Category.BACKWARD_INCOMPATIBLE, "Same as #1\n");
 
     ReleaseNoteCreation sut = new ReleaseNoteCreation(ghContextMock);
     sut.extractReleaseNoteInfo("1");
     sut.extractReleaseNoteInfo("2");
     sut.extractReleaseNoteInfo("3");
     sut.extractReleaseNoteInfo("4");
+    sut.extractReleaseNoteInfo("5");
 
     // Act
     sut.assortSameAsItems();
@@ -119,6 +122,8 @@ public class ReleaseNoteCreationTest {
         sut.categoryMap;
     List<ReleaseNoteCreation.ReleaseNoteText> releaseNoteTexts;
 
+    releaseNoteTexts = categoryMap.get(ReleaseNoteCreation.Category.BACKWARD_INCOMPATIBLE);
+    assertThat(releaseNoteTexts).isEmpty();
     releaseNoteTexts = categoryMap.get(ReleaseNoteCreation.Category.IMPROVEMENT);
     assertThat(releaseNoteTexts).isEmpty();
     releaseNoteTexts = categoryMap.get(ReleaseNoteCreation.Category.BUGFIX);
@@ -129,7 +134,7 @@ public class ReleaseNoteCreationTest {
     assertThat(releaseNoteTexts.size()).isEqualTo(1);
 
     ReleaseNoteCreation.ReleaseNoteText releaseNoteText = releaseNoteTexts.get(0);
-    assertThat(releaseNoteText.prNumbers).containsOnly("1", "2", "3", "4");
+    assertThat(releaseNoteText.prNumbers).containsOnly("1", "2", "3", "4", "5");
     assertThat(releaseNoteText.category).isEqualTo(ReleaseNoteCreation.Category.ENHANCEMENT);
     assertThat(releaseNoteText.text)
         .isEqualTo("A topic pull request. Additional comment 1. Additional comment 2.");
@@ -182,11 +187,19 @@ public class ReleaseNoteCreationTest {
         ReleaseNoteCreation.Category.BUGFIX,
         "Same as #1\nAdditional comment 2.");
     addMockBehaviourToGitHubContext(
-        ghContextMock, "5", ReleaseNoteCreation.Category.IMPROVEMENT, "An improvement text");
+        ghContextMock, "5", ReleaseNoteCreation.Category.IMPROVEMENT, "An improvement text.");
     addMockBehaviourToGitHubContext(
-        ghContextMock, "6", ReleaseNoteCreation.Category.BUGFIX, "A bugfix text");
+        ghContextMock, "6", ReleaseNoteCreation.Category.BUGFIX, "A bugfix text.");
     addMockBehaviourToGitHubContext(
-        ghContextMock, "7", ReleaseNoteCreation.Category.DOCUMENTATION, "A documentation text");
+        ghContextMock,
+        "7",
+        ReleaseNoteCreation.Category.BACKWARD_INCOMPATIBLE,
+        "A backward-incompatible text 1.");
+    addMockBehaviourToGitHubContext(
+        ghContextMock,
+        "8",
+        ReleaseNoteCreation.Category.BACKWARD_INCOMPATIBLE,
+        "A backward-incompatible text 2.");
 
     ReleaseNoteCreation sut = new ReleaseNoteCreation(ghContextMock);
     sut.extractReleaseNoteInfo("1");
@@ -196,18 +209,20 @@ public class ReleaseNoteCreationTest {
     sut.extractReleaseNoteInfo("5");
     sut.extractReleaseNoteInfo("6");
     sut.extractReleaseNoteInfo("7");
+    sut.extractReleaseNoteInfo("8");
     sut.assortSameAsItems();
 
     String expected =
         "## Summary\n\n"
+            + "## Backward incompatibles\n"
+            + "- A backward-incompatible text 1. (#7)\n"
+            + "- A backward-incompatible text 2. (#8)\n\n"
             + "## Enhancements\n"
             + "- A topic pull request. Additional comment 1. Additional comment 2. (#1 #2 #3 #4)\n\n"
             + "## Improvements\n"
-            + "- An improvement text (#5)\n\n"
+            + "- An improvement text. (#5)\n\n"
             + "## Bug fixes\n"
-            + "- A bugfix text (#6)\n\n"
-            + "## Documentation\n"
-            + "- A documentation text (#7)\n\n\n";
+            + "- A bugfix text. (#6)\n\n\n";
 
     final ByteArrayOutputStream baos = new ByteArrayOutputStream(); // Capture the standard output
     System.setOut(new PrintStream(baos, false, StandardCharsets.UTF_8));
@@ -222,11 +237,12 @@ public class ReleaseNoteCreationTest {
 
   static Stream<Arguments> extractReleaseNoteInfo_normalText_addedCorrectCategory() {
     return Stream.of(
-        arguments(ReleaseNoteCreation.Category.ENHANCEMENT, "a release note text in enhancements"),
-        arguments(ReleaseNoteCreation.Category.IMPROVEMENT, "a release note text in iimporvements"),
-        arguments(ReleaseNoteCreation.Category.BUGFIX, "a release note text in bugfixes"),
         arguments(
-            ReleaseNoteCreation.Category.DOCUMENTATION, "a release note text in documentation"),
+            ReleaseNoteCreation.Category.BACKWARD_INCOMPATIBLE,
+            "a release note text in backward incompatibles"),
+        arguments(ReleaseNoteCreation.Category.ENHANCEMENT, "a release note text in enhancements"),
+        arguments(ReleaseNoteCreation.Category.IMPROVEMENT, "a release note text in improvements"),
+        arguments(ReleaseNoteCreation.Category.BUGFIX, "a release note text in bug fixes"),
         arguments(
             ReleaseNoteCreation.Category.MISCELLANEOUS, "a release note text in miscellaneous"));
   }

--- a/release-note-script/src/test/resources/cluster.md
+++ b/release-note-script/src/test/resources/cluster.md
@@ -1,7 +1,7 @@
 ## Summary
 A dummy ScalarDB Cluster release note.
 
-## Backward incompatibles
+## Backward incompatible changes
 - A backward incompatible text of ScalarDB Cluster (#5)
 
 ## Enhancements

--- a/release-note-script/src/test/resources/cluster.md
+++ b/release-note-script/src/test/resources/cluster.md
@@ -1,6 +1,9 @@
 ## Summary
 A dummy ScalarDB Cluster release note.
 
+## Backward incompatibles
+- A backward incompatible text of ScalarDB Cluster (#5)
+
 ## Enhancements
 - An enhancement text of ScalarDB Cluster (#1)
 
@@ -9,6 +12,3 @@ A dummy ScalarDB Cluster release note.
 
 ## Bug fixes
 - A bug fixe text of ScalarDB Cluster [CVE-1234-5678](dummy) (#3)
-
-## Documentation
-- A documentation text of ScalarDB Cluster (#4)

--- a/release-note-script/src/test/resources/expected.md
+++ b/release-note-script/src/test/resources/expected.md
@@ -1,16 +1,23 @@
 ## Summary
 
 ## Community edition
+### Backward incompatibles
+- A backward incompatible text of ScalarDB (#5)
 ### Enhancements
 - An enhancement text of ScalarDB (#1)
 ### Improvements
 - An improvement text of ScalarDB (#2)
 ### Bug fixes
 - A bug fixe text of ScalarDB [CVE-1234-5678](dummy) (#3)
-### Documentation
-- A documentation text of ScalarDB (#4)
 
 ## Enterprise edition
+### Backward incompatibles
+#### ScalarDB Cluster
+- A backward incompatible text of ScalarDB Cluster
+#### ScalarDB GraphQL
+- A backward incompatible text of ScalarDB GraphQL
+#### ScalarDB SQL
+- A backward incompatible text of ScalarDB SQL
 ### Enhancements
 #### ScalarDB Cluster
 - An enhancement text of ScalarDB Cluster
@@ -32,11 +39,4 @@
 - A bug fixe text of ScalarDB GraphQL [CVE-1234-5678](dummy)
 #### ScalarDB SQL
 - A bug fixe text of ScalarDB SQL [CVE-1234-5678](dummy)
-### Documentation
-#### ScalarDB Cluster
-- A documentation text of ScalarDB Cluster
-#### ScalarDB GraphQL
-- A documentation text of ScalarDB GraphQL
-#### ScalarDB SQL
-- A documentation text of ScalarDB SQL
 

--- a/release-note-script/src/test/resources/expected.md
+++ b/release-note-script/src/test/resources/expected.md
@@ -1,7 +1,7 @@
 ## Summary
 
 ## Community edition
-### Backward incompatibles
+### Backward incompatible changes
 - A backward incompatible text of ScalarDB (#5)
 ### Enhancements
 - An enhancement text of ScalarDB (#1)
@@ -11,7 +11,7 @@
 - A bug fixe text of ScalarDB [CVE-1234-5678](dummy) (#3)
 
 ## Enterprise edition
-### Backward incompatibles
+### Backward incompatible changes
 #### ScalarDB Cluster
 - A backward incompatible text of ScalarDB Cluster
 #### ScalarDB GraphQL

--- a/release-note-script/src/test/resources/graphql.md
+++ b/release-note-script/src/test/resources/graphql.md
@@ -1,6 +1,9 @@
 ## Summary
 A dummy ScalarDB GraphQL release note.
 
+## Backward incompatibles
+- A backward incompatible text of ScalarDB GraphQL (#5)
+
 ## Enhancements
 - An enhancement text of ScalarDB GraphQL (#1)
 
@@ -9,6 +12,3 @@ A dummy ScalarDB GraphQL release note.
 
 ## Bug fixes
 - A bug fixe text of ScalarDB GraphQL [CVE-1234-5678](dummy) (#3)
-
-## Documentation
-- A documentation text of ScalarDB GraphQL (#4)

--- a/release-note-script/src/test/resources/graphql.md
+++ b/release-note-script/src/test/resources/graphql.md
@@ -1,7 +1,7 @@
 ## Summary
 A dummy ScalarDB GraphQL release note.
 
-## Backward incompatibles
+## Backward incompatible changes
 - A backward incompatible text of ScalarDB GraphQL (#5)
 
 ## Enhancements

--- a/release-note-script/src/test/resources/scalardb.md
+++ b/release-note-script/src/test/resources/scalardb.md
@@ -1,6 +1,9 @@
 ## Summary
 A dummy ScalarDB release note.
 
+## Backward incompatibles
+- A backward incompatible text of ScalarDB (#5)
+
 ## Enhancements
 - An enhancement text of ScalarDB (#1)
 
@@ -9,6 +12,3 @@ A dummy ScalarDB release note.
 
 ## Bug fixes
 - A bug fixe text of ScalarDB [CVE-1234-5678](dummy) (#3)
-
-## Documentation
-- A documentation text of ScalarDB (#4)

--- a/release-note-script/src/test/resources/scalardb.md
+++ b/release-note-script/src/test/resources/scalardb.md
@@ -1,7 +1,7 @@
 ## Summary
 A dummy ScalarDB release note.
 
-## Backward incompatibles
+## Backward incompatible changes
 - A backward incompatible text of ScalarDB (#5)
 
 ## Enhancements

--- a/release-note-script/src/test/resources/sql.md
+++ b/release-note-script/src/test/resources/sql.md
@@ -1,7 +1,7 @@
 ## Summary
 A dummy ScalarDB SQL release note.
 
-## Backward incompatibles
+## Backward incompatible changes
 - A backward incompatible text of ScalarDB SQL (#5)
 
 ## Enhancements

--- a/release-note-script/src/test/resources/sql.md
+++ b/release-note-script/src/test/resources/sql.md
@@ -1,6 +1,9 @@
 ## Summary
 A dummy ScalarDB SQL release note.
 
+## Backward incompatibles
+- A backward incompatible text of ScalarDB SQL (#5)
+
 ## Enhancements
 - An enhancement text of ScalarDB SQL (#1)
 
@@ -9,6 +12,3 @@ A dummy ScalarDB SQL release note.
 
 ## Bug fixes
 - A bug fixe text of ScalarDB SQL [CVE-1234-5678](dummy) (#3)
-
-## Documentation
-- A documentation text of ScalarDB SQL (#4)


### PR DESCRIPTION
## Description

This PR modifies the release notes category according to the [Guidelines](https://developers.scalar-labs.com/docs/style-guide/release-notes/)

## Related issues and/or PRs

N/A

## Changes made

- Adds `backward-incompatible` category to the release notes
- Remove `documentation` category from the release notes

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
