### PR TITLE
Increase the limit of retrieved pull requests

### DIFF
--- a/release-note-script/src/main/java/ReleaseNoteCreation.java
+++ b/release-note-script/src/main/java/ReleaseNoteCreation.java
@@ -258,6 +258,7 @@ public class ReleaseNoteCreation {
   public static class GitHubContext {
 
     private static final String MERGED_STATE = "merged";
+    private static final int LIMIT_NUMBER_OF_RETRIEVE_PULL_REQUESTS = 10000;
 
     private final String owner;
     private final String projectTitlePrefix;
@@ -272,10 +273,14 @@ public class ReleaseNoteCreation {
     }
 
     private String getProjectId() throws Exception {
+      /*
+       * Includes closed project if we get the project list so that we can run
+       * this script to the closed project for debug.
+       */
       BufferedReader br =
           runSubProcessAndGetOutputAsReader(
               format(
-                  "gh project list --owner %s | awk '/%s/ {print}' | awk '/%s/ {print $1}'",
+                  "gh project list --owner %s --closed | awk '/%s/ {print}' | awk '/%s/ {print $1}'",
                   this.owner, this.projectTitlePrefix, this.version));
 
       String line = br.readLine(); // Assuming only one line exists.
@@ -287,9 +292,9 @@ public class ReleaseNoteCreation {
       BufferedReader br =
           runSubProcessAndGetOutputAsReader(
               format(
-                  "gh project item-list %s --owner %s --limit 200 | awk -F'\\t' '/%s\\t/ {print"
+                  "gh project item-list %s --owner %s --limit %d | awk -F'\\t' '/%s\\t/ {print"
                       + " $3}'",
-                  projectId, this.owner, this.repository));
+                  projectId, this.owner, LIMIT_NUMBER_OF_RETRIEVE_PULL_REQUESTS, this.repository));
 
       String line;
       List<String> prNumbers = new ArrayList<>();


### PR DESCRIPTION
## Description

This pull request fixes a bug where the generated release notes didn't include all necessary pull requests (PRs) by increasing the limit number of retrieving PRs from a project in GitHub.

This bug occurred because the upper limit was set to 200 when retrieving pull requests associated with a GitHub project.  However, there were 297 pull requests for v3.11.0, but 97 of them were missed during retrieval.

## Related issues and/or PRs

NA

## Changes made

- Increased the limit for pull requests retrieved using the `gh project item-list` command from 200 to 10000 to prevent any omissions.
- To make debugging easier, Modified the `gh project` command to include the `--closed` option when retrieving a list of GitHub projects. This allows information to be obtained for closed projects as well.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

NA

## Release notes

NA
