### PR TITLE
Remove suffix after the dash from version in ReleaseNoteCreation

### DIFF
--- a/release-note-script/src/main/java/ReleaseNoteCreation.java
+++ b/release-note-script/src/main/java/ReleaseNoteCreation.java
@@ -281,11 +281,20 @@ public class ReleaseNoteCreation {
           runSubProcessAndGetOutputAsReader(
               format(
                   "gh project list --owner %s --closed | awk '/%s/ {print}' | awk '/%s/ {print $1}'",
-                  this.owner, this.projectTitlePrefix, this.version));
+                  this.owner, this.projectTitlePrefix, getVersion()));
 
       String line = br.readLine(); // Assuming only one line exists.
       if (line == null) throw new RuntimeException("Couldn't get the projectId");
       return line;
+    }
+
+    private String getVersion() {
+      int index = this.version.indexOf("-");
+      if (index == -1) {
+        return this.version;
+      }
+      // Remove the suffix after the dash. (e.g., 4.0.0-rc1 -> 4.0.0)
+      return this.version.substring(0, index);
     }
 
     private List<String> getPullRequestNumbers(String projectId) throws Exception {


### PR DESCRIPTION
## Description

We sometimes use versions with suffixes, such as `4.0.0-rc1` or `4.0.0-alpha.1`. This PR adds support for those versions in `ReleaseNoteCreation`.

## Related issues and/or PRs

N/A

## Changes made

> Outline the specific changes made in this pull request. Include relevant details, such as added features, bug fixes, code refactoring, or improvements.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
