### PR TITLE
Fix getPullRequestNumbers() of ReleaseNoteCreation

### DIFF
--- a/release-note-script/src/main/java/ReleaseNoteCreation.java
+++ b/release-note-script/src/main/java/ReleaseNoteCreation.java
@@ -301,7 +301,7 @@ public class ReleaseNoteCreation {
       BufferedReader br =
           runSubProcessAndGetOutputAsReader(
               format(
-                  "gh project item-list %s --owner %s --limit %d | awk -F'\\t' '/%s\\t/ {print"
+                  "gh project item-list %s --owner %s --limit %d | awk -F'\\t' '/\\/%s\\t/ {print"
                       + " $3}'",
                   projectId, this.owner, LIMIT_NUMBER_OF_RETRIEVE_PULL_REQUESTS, this.repository));
 


### PR DESCRIPTION
## Description

This PR fixes the bug in `getPullRequestNumbers()` of `ReleaseNoteCreation`.

## Related issues and/or PRs

N/A

## Changes made

- Added a slash before the repository name to distinguish between `scalardb` and `docs-internal-scalardb`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
