### PR TITLE
Add reusable vulnerability check workflow

### DIFF
--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -1,0 +1,151 @@
+name: Vulnerability Check
+
+on:
+  workflow_call:
+    inputs:
+      target-ref:
+        description: 'Target ref (branch, tag, release) to scan'
+        required: true
+        type: string
+        default: 'main'
+      find-latest-release:
+        description: 'Flag to find the latest version for specified `target-ref`'
+        required: false
+        type: boolean
+        default: false
+      images:
+        description: "JSON string representing a list of pairs of names and image base names of Docker images. For example, if `'[[\"ScalarDL Ledger\", \"scalar-ledger\"], [\"ScalarDL Auditor\", \"scalar-auditor\"]'` is specified, the scanner will scan `ghcr.io/scalar-labs/scalar-ledger:<tag>` and `ghcr.io/scalar-labs/scalar-auditor:<tag>`."
+        required: true
+        type: string
+      version-command:
+        description: 'Shell command that prints the version string. It is used as the tag for Docker images to be scanned.'
+        required: false
+        type: string
+        default: "./gradlew :common:properties -q | grep version: | awk '{print $2}'"
+    secrets:
+      CR_PAT:
+        required: true
+      SLACK_SECURITY_WEBHOOK_URL:
+        required: true
+
+env:
+  TERM: dumb
+  GPR_USERNAME: ${{ github.repository_owner }}
+  GPR_PASSWORD: ${{ secrets.CR_PAT }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.CR_PAT }}
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout vuln-check scripts
+        uses: actions/checkout@v4
+        with:
+          repository: scalar-labs/actions
+          sparse-checkout: vuln-check-script
+          ref: main
+          path: vuln-check
+
+      - id: prepare-target-ref
+        name: Prepare target-ref
+        env:
+          SCRIPT_PATH: ./vuln-check/vuln-check-script
+        run: |
+          # Find the latest release name if `find-latest-release` is set to true. Use the value of `target-ref` as is otherwise.
+          if [[ ${{ inputs.find-latest-release }} = 'true' ]]; then
+            releases=$($SCRIPT_PATH/fetch_gh_releases "${{ github.event.repository.owner.login }}" "${{ github.event.repository.name }}")
+            echo -------------
+            echo "releases: $releases"
+            echo -------------
+            target_release=''
+            if [[ -n $releases ]]; then
+              target_release=$($SCRIPT_PATH/find_latest_release "${{ inputs.target-ref }}" $releases)
+            fi
+            if [[ -z $target_release ]]; then
+              echo "Can't find a target release"
+              exit 1
+            fi
+            echo $target_release
+            echo "target-ref=$target_release" >> $GITHUB_OUTPUT
+          else
+            echo "target-ref=${{ inputs.target-ref }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout the target repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.prepare-target-ref.outputs.target-ref }}
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Docker build
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: docker
+
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(${{ inputs.version-command }})
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+  vuln-check:
+    runs-on: ubuntu-latest
+
+    needs: build
+
+    strategy:
+      matrix:
+        image: ${{ fromJSON(inputs.images) }}
+      fail-fast: false
+      max-parallel: 1
+
+    continue-on-error: true
+
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Run Trivy vulnerability scanner for ${{ matrix.image[0] }}
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/scalar-labs/${{ matrix.image[1] }}:${{ needs.build.outputs.version }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+          timeout: '60m'
+
+      - name: Post Trivy vulnerability check failure for ${{ matrix.image[0] }}
+        if: failure()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":octagonal_sign: The vulnerability check for ${{ matrix.image[0] }} on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -24,6 +24,7 @@ on:
         default: "./gradlew :common:properties -q | grep version: | awk '{print $2}'"
     secrets:
       CR_PAT:
+        description: 'GitHub Personal Access Token (PAT) to access GitHub Container Registry. It is also used for GitHub CLI (GH_TOKEN).'
         required: true
       SLACK_SECURITY_WEBHOOK_URL:
         required: true

--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -27,7 +27,8 @@ on:
         description: 'GitHub Personal Access Token (PAT) to access GitHub Container Registry. It is also used for GitHub CLI (GH_TOKEN).'
         required: true
       SLACK_SECURITY_WEBHOOK_URL:
-        required: true
+        description: 'Slack webhook URL to post vulnerability check failure. If empty, the action will not post a message.'
+        required: false
 
 env:
   TERM: dumb
@@ -114,6 +115,17 @@ jobs:
     continue-on-error: true
 
     steps:
+      - name: Check if Slack webhook URL is set
+        id: slack-webhook
+        run: |
+          if [[ -n "${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}" ]]; then
+            echo "Slack webhook URL is set. Post a message if the vulnerability check fails."
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "Slack webhook URL is not set. Skip posting a message."
+            echo "enabled=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -132,7 +144,7 @@ jobs:
           timeout: '60m'
 
       - name: Post Trivy vulnerability check failure for ${{ matrix.image[0] }}
-        if: failure()
+        if: failure() && steps.slack-webhook.outputs.enabled == 'true'
         uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |

--- a/vuln-check-script/fetch_gh_releases
+++ b/vuln-check-script/fetch_gh_releases
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 repo_owner repo_name"
+    exit 1
+fi
+
+repo_owner=$1
+repo_name=$2
+
+# Get all GitHub releases by following subsequent pages using --paginate option
+releases=$(gh api graphql --paginate -F owner=$repo_owner -F repoName=$repo_name -F endCursor="" -f query='
+  query($owner: String!, $repoName: String!, $endCursor: String!) {
+    repository(owner: $owner, name: $repoName) {
+      releases(first: 100, after: $endCursor) {
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        nodes {
+          name
+        }
+      }
+    }
+  }
+')
+
+# $releases is JSONL like the following. So extracting only `name` here makes subsequent processing simpler
+#
+# ```
+# {"data":{"repository":{"releases":{"pageInfo":{"endCursor":"Mg","hasNextPage":true},"nodes":[{"name":"v3.10.10"},{"name":"v3.10.1"}]}}}}
+# {"data":{"repository":{"releases":{"pageInfo":{"endCursor":"NA","hasNextPage":true},"nodes":[{"name":"v3.9.10"},{"name":"v3.9.9"}]}}}}
+# {"data":{"repository":{"releases":{"pageInfo":{"endCursor":"Ng","hasNextPage":false},"nodes":[{"name":"v3.8.1"},{"name":"v3.8.0"}]}}}}
+# ```
+
+# Output:
+#
+# ```
+# v3.10.10
+# v3.10.1
+#    :
+# v3.8.0
+# ```
+echo $releases | jq -r -s 'map(.data.repository.releases.nodes) | flatten | map(.name)' | jq -r '.[]'

--- a/vuln-check-script/find_latest_release
+++ b/vuln-check-script/find_latest_release
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby
+
+if ARGV.empty?
+  raise "usage: #{$0} release_pattern release..."
+end
+
+# This argument can be a full release name (e.g., v3.9.2) or a prefix (e.g., v3.9)
+release_pattern = ARGV.shift
+if release_pattern.end_with?('.')
+  # Remove a tailing dot if exists
+  release_pattern = release_pattern[0...-1]
+end
+# This set of arguments consists of all existing release names
+releases = ARGV
+
+# `candidate_releases` is a map and consists of the following elements
+#   key: a partial version integer (e.g., 9 out of "v3.9.1")
+#   value: a next nested map for subsequent partial version integers
+#
+# For instance, let's say `releases` are
+# - v3.8.11
+# - v3.8.12
+# - v3.9.9
+# - v3.9.10
+# - v3.10.0
+# - v3.10.1
+#
+# If `release_pattern` is `v3`,
+# `candidate_releases` will be as follows
+# {
+#   8: {
+#     11: {},
+#     12: {}
+#   }
+#   9: {
+#     9: {},
+#     10: {}
+#   }
+#   10: {
+#     0: {},
+#     1: {}
+#   }
+# }
+#
+# If `release_pattern` is `v3.9`,
+# `candidate_releases` will be as follows
+# {
+#   9: {
+#     9: {},
+#     10: {}
+#   }
+# }
+#
+# And then, the latest release name can be built by picking a max partial version
+# step by step (e.g., "v3.10.1" and "v3.9.10")
+
+found = false
+candidate_releases = {}
+releases.each do |release|
+  if release.start_with?(release_pattern)
+    found = true
+    # Get the rest of string after `release_pattern` (e.g., "9.1")
+    rest_versions = release[release_pattern.size..]
+    cur = candidate_releases
+
+    # Validate `rest_versions`
+    begin
+      rest_versions.split('.').each do |x|
+        # Empty string is expected
+        Integer(x) unless x.empty?
+      end
+    rescue ArgumentError
+      STDERR.puts "Found invalid version unit '#{rest_versions}'. Skipping it."
+      next
+    end
+
+    # Update `candidate_releases`
+    rest_versions.split('.').each do |part_of_version_str|
+      next if part_of_version_str.empty?
+      part_of_version = Integer(part_of_version_str)
+      # Just an idiom for map initialization
+      cur[part_of_version] ||= {}
+      cur = cur[part_of_version]
+    end
+  end
+end
+
+return unless found
+
+cur = candidate_releases
+full_release_name = release_pattern.dup
+loop do
+  if cur.empty?
+    puts full_release_name
+    return
+  end
+  # Always choose the max partial version integer,
+  # construct the full release name and traverse the map
+  part_of_version, next_versions = cur.max
+  full_release_name << ".#{part_of_version}"
+  cur = next_versions
+end


### PR DESCRIPTION
## Description

Several repositories have vulnerability checks against Docker images with manual triggers and scheduled runs. Currently, each repository has duplicate workflows for this purpose. This PR extracts the shared tasks as a reusable workflow to reduce code duplication.

## Related issues and/or PRs

- scalar-labs/scalardb#737
- scalar-labs/scalardb#986
- scalar-labs/scalardb-cluster#36
- scalar-labs/scalardb-cluster#144
- scalar-labs/scalar#885
- scalar-labs/scalar#1231
- #6

PRs to call this reusable workflow:

- https://github.com/scalar-labs/scalardb/pull/2288
- https://github.com/scalar-labs/scalardb-cluster/pull/812
- https://github.com/scalar-labs/scalar/pull/1276

## Changes made

### Workflow yaml file

Copied and modified vulnerability check workflow in `scalardb`, `scalardb-cluster`, and `scalar` repositories so that it can be called from each repository.

### Utility scripts to find the latest release

Utility scripts to find the latest release on GitHub located in the `ci/vuln-check/`directory have also been copied to this repo's `voln-check-script/` directory.

### Inputs added

#### `images`

Since one repository creates one or more Docker images, the original workflows run the Trivy vulnerability scanner multiple times for each image in one workflow job. To handle this, the reusable workflow uses GitHub Action's [matrix strategy](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow). A list for specifying what images to scan is defined as the workflow input named `images`. When calling this workflow, you must pass Docker image names (for humans) and the image basenames. The list should be passed as a JSON string since the workflow input type cannot be a list.

Example: `'[["ScalarDL Ledger", "scalar-ledger"], ["ScalarDL Auditor", "scalar-auditor"]'`.

#### `version-command`

The version strings to tag the Docker images are defined as the property `project.version` in `build.gradle`. The original workflow uses a `gradlew` command to output it. However, this command varies depending on the repository (`./gradlew :common:properties` for `scalar` and `scalardb-cluster`, and `./gradlew :core:properties` for `scalardb`). For this reason, I made it possible to pass this command as an input. This command could be unified among the repositories, but I have chosen this solution for now.

### Posting failure message to Slack optionally

This PR makes the Slack webhook URL secret not required. If the caller workflow does not pass the `SLACK_SECURITY_WEBHOOK_URL` secret, the reusable workflow does not post a message even if the vuln-check fails.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
