### PR TITLE
Fix deprecation of `gradle/gradle-build-action` action

### DIFF
--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -90,10 +90,11 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Docker build
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: docker
+        run: ./gradlew docker
 
       - name: Set version
         id: version


### PR DESCRIPTION
## Description

This PR replaces the `gradle/gradle-build-action` action with the `gradle/actions/setup-gradle` action since it has been [deprecated](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md).

## Related issues and/or PRs

- #9

## Changes made

1. Replaced `uses: gradle/gradle-build-action@v3` with the `uses: gradle/actions/setup-gradle@v4`
2. Removed the deprecated `arguments` parameter and added a new step to run the `./gradlew docker` command

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
