### PR TITLE
Configure dependabot to check Github actions update weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # For GitHub Actions workflows, update all actions on the main branch
+  - package-ecosystem: "github-actions"
+    groups:
+      actions on main branch:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"


### PR DESCRIPTION
## Description
This repository contains the team-wide used vuln-check and auto-PR Actions workflows but we did not configure Dependabot to update their actions like we do for other repositories. 

So this PR configures Dependabot to check updates for GitHub actions weekly.

## Related issues and/or PRs

N/A

## Changes made

Add a Dependabot configuration file to check for Github actions weekly

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
