### PR TITLE
Fix auto-PR

### DIFF
--- a/auto-pr-script/create_pull_requests
+++ b/auto-pr-script/create_pull_requests
@@ -21,8 +21,8 @@ branches=("$@")
 
 function main(){
 	# Use the author info of the original Git commit
-	git config --global user.email $(git show -s --format='%ae' $commit_sha)
-	git config --global user.name $(git show -s --format='%an' $commit_sha)
+	git config --global user.email "$(git show -s --format='%ae' "$commit_sha")"
+	git config --global user.name "$(git show -s --format='%an' "$commit_sha")"
 
 	git fetch origin
 
@@ -49,7 +49,7 @@ function cherry_pick_and_create_pull_request () {
 	if git cherry-pick --no-rerere-autoupdate -m1 $commit_sha;
 	then
 		# If the cherry-pick succeeds, creates the backport PR with it
-		git push origin $new_branch
+		git push -u origin $new_branch
 		git status
 		pr_body=$(get_successfull_backport_pr_body)
 		create_pr $branch "${pr_body}"
@@ -57,7 +57,7 @@ function cherry_pick_and_create_pull_request () {
 		# If the cherry-pick fails, creates the backport PR draft containing an empty commit
 		git cherry-pick --abort
 		git commit --allow-empty -m "Empty commit [skip ci]"
-		git push origin $new_branch
+		git push -u origin $new_branch
 		git status
 		pr_body=$(get_failed_backport_pr_body)
 		create_pr $branch "${pr_body}" --draft


### PR DESCRIPTION
## Description

This contains two fixes:
- For an issue that we experienced when Thong was the PR assignee due to some input not being properly escaped.
- For an issue affecting the Github CLI v2.64.0 used in the Github actions images when creating a PR. See. https://github.com/cli/cli/issues/10188 . The latest CLI version v2.65.0 contains the bugfix but this version is not yet deployed to the Github action runner images so we need to apply a workaround.
  

## Related issues and/or PRs

N/A

## Changes made

Applies two fixes to `auto-pr-script/create_pull_requests`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
