### PR TITLE
Fix vulnerability-check action

### DIFF
--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -148,18 +148,12 @@ jobs:
         if: failure() && steps.slack-webhook.outputs.enabled == 'true'
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":octagonal_sign: The vulnerability check for ${{ matrix.image[0] }} on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: ":octagonal_sign: The vulnerability check for ${{ matrix.image[0] }} on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
+


### PR DESCRIPTION
## Description

The vuln-check action failed to post the result of the vulnerability check on the `#eng-security` Slack channel. 
The reason is that the `slackapi/slack-github-action`  was updated to the latest major version `2.0.0` in https://github.com/scalar-labs/actions/pull/12 which brings breaking changes regarding the usage syntax.

This PR updates the syntax to call the `slackapi/slack-github-action`

## Related issues and/or PRs

- https://github.com/scalar-labs/actions/pull/12

## Changes made

Updates the syntax to call the `slackapi/slack-github-action`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
