### PR TITLE
Enable Docker image sharing via artifacts in vulnerability-check workflow

### DIFF
--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -102,6 +102,19 @@ jobs:
           VERSION=$(${{ inputs.version-command }})
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
+      - name: Save Docker images
+        run: |
+          docker image ls
+          images=`echo '${{ inputs.images }}' | jq -r '[.[] | "ghcr.io/scalar-labs/" + .[1] + ":${{ steps.version.outputs.version }}"] | join(" ")'`
+          echo "Images to save: $images"
+          docker save $images -o docker-images.tar
+
+      - name: Upload images as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-images
+          path: docker-images.tar
+
   vuln-check:
     runs-on: ubuntu-latest
 
@@ -127,12 +140,13 @@ jobs:
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Download Docker images artifact
+        uses: actions/download-artifact@v4
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          name: docker-images
+
+      - name: Load Docker images
+        run: docker load -i docker-images.tar
 
       - name: Run Trivy vulnerability scanner for ${{ matrix.image[0] }}
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -116,6 +116,7 @@ jobs:
         with:
           name: docker-images
           path: images_output
+          retention-days: 1
 
   vuln-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -104,16 +104,18 @@ jobs:
 
       - name: Save Docker images
         run: |
-          docker image ls
-          images=`echo '${{ inputs.images }}' | jq -r '[.[] | "ghcr.io/scalar-labs/" + .[1] + ":${{ steps.version.outputs.version }}"] | join(" ")'`
-          echo "Images to save: $images"
-          docker save $images -o docker-images.tar
+          mkdir -p images_output
+          for label in $(echo '${{ inputs.images }}' | jq -r .[][1])
+          do
+              image="ghcr.io/scalar-labs/${label}:${{ steps.version.outputs.version }}"
+              docker save $image | gzip > images_output/${label}.tar.gz
+          done
 
       - name: Upload images as artifact
         uses: actions/upload-artifact@v4
         with:
           name: docker-images
-          path: docker-images.tar
+          path: images_output
 
   vuln-check:
     runs-on: ubuntu-latest
@@ -145,8 +147,8 @@ jobs:
         with:
           name: docker-images
 
-      - name: Load Docker images
-        run: docker load -i docker-images.tar
+      - name: Load Docker image
+        run: docker load -i ${{ matrix.image[1] }}.tar.gz
 
       - name: Run Trivy vulnerability scanner for ${{ matrix.image[0] }}
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
## Description

The vulnerability-check reusable workflow introduced in #9 has not been working as intended. It runs in two separate jobs:

1. Building Docker images from the repository.
2. Running the vulnerability check with Trivy.

Since these jobs run on different runners,  the Docker images built in the first job are not available in the second. As a result, Trivy scans the previously pushed images from the remote ghcr.io registry instead of the freshly built ones.

This PR addresses the issue by adding steps to transfer the built Docker images between jobs using GitHub Actions artifacts. This enables the second job to scan the images built in the first job.

## Related issues and/or PRs

- #17
- #9
- #10

## Changes made

1. Added steps to run `docker save` and upload the images as artifacts in the first job.
2. Added steps to download the artifacts and load the images with `docker load` in the subsequent jobs.
4. Removed the login step to ghcr.io, as it is no longer necessary.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes

The `CR_PAT` secret is no longer required. However, removing it would cause the caller workflows to fail as they currently pass it as an input. After this PR is approved and merged, I will submit follow-up PRs related to the removal of CR_PAT.
Environment variables such as `GPR_USERNAME`, `GPR_PASSWORD`, and `GH_TOKEN` can also be removed at that time.

## Release notes

Enable scanning of built Docker images in the vulnerability-check workflow by sharing them between jobs via artifacts.
