### PR TITLE
Fix artifact name conflict in vulnerability check workflow

### DIFF
--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Upload images as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: docker-images-${{ github.run_id }}-${{ github.run_attempt }}
+          name: docker-images-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.target-ref }}
           path: images_output
           retention-days: 1
 
@@ -146,7 +146,7 @@ jobs:
       - name: Download Docker images artifact
         uses: actions/download-artifact@v4
         with:
-          name: docker-images-${{ github.run_id }}-${{ github.run_attempt }}
+          name: docker-images-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.target-ref }}
 
       - name: Load Docker image
         run: docker load -i ${{ matrix.image[1] }}.tar.gz


### PR DESCRIPTION
## Description

This is an additional PR for #20. It fixes an artifact name conflict error in the `vuln-check-reusable.yaml` workflow. This error occurs when the workflow is called multiple times within a single workflow run (e.g., for different target refs in a [scheduled workflow](https://github.com/scalar-labs/scalardb/blob/master/.github/workflows/scheduled-vuln-check.yaml), such as master, v3.15, v3.16).

Example of the error: https://github.com/scalar-labs/scalardb/actions/runs/16426892718

## Related issues and/or PRs

- #19
- #20

## Changes made

- Modified the artifact name in `vuln-check-reusable.yaml` to include `${{ inputs.target-ref }}` in addition to `${{ github.run_id }}-${{ github.run_attempt }}`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Release notes

Fixed artifact name conflict in vulnerability check workflow when called multiple times with different target references in a single workflow run.
