### PR TITLE
Remove CR_PAT requirement from vulnerability check workflow

### DIFF
--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -23,24 +23,19 @@ on:
         type: string
         default: "./gradlew :common:properties -q | grep version: | awk '{print $2}'"
     secrets:
-      CR_PAT:
-        description: 'GitHub Personal Access Token (PAT) to access GitHub Container Registry. It is also used for GitHub CLI (GH_TOKEN).'
-        required: true
       SLACK_SECURITY_WEBHOOK_URL:
         description: 'Slack webhook URL to post vulnerability check failure. If empty, the action will not post a message.'
         required: false
 
 env:
   TERM: dumb
-  GPR_USERNAME: ${{ github.repository_owner }}
-  GPR_PASSWORD: ${{ secrets.CR_PAT }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     env:
-      GH_TOKEN: ${{ secrets.CR_PAT }}
+      GH_TOKEN: ${{ github.token }}
 
     outputs:
       version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Description

This PR removes the requirement for the `CR_PAT` secret from the `vuln-check-reusable.yaml` workflow. Since this workflow no longer interacts with the container registry after the changes in #19, the CR_PAT is no longer needed.

The workflow now uses the built-in `github.token` for GitHub CLI operations instead.

## Related issues and/or PRs

- #19
- #20
- #22

## Changes made

- Removed `CR_PAT` from the required secrets in the workflow inputs
- Removed `GPR_USERNAME` and `GPR_PASSWORD` environment variables that were using `CR_PAT`
- Changed `GH_TOKEN` to use `${{ github.token }}` instead of `${{ secrets.CR_PAT }}`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

 ## Additional notes

**Breaking Change:** This removes the `CR_PAT` secret parameter. Repositories using this workflow must remove `CR_PAT` from their workflow calls. Please update dependent repositories simultaneously with this PR merge to avoid workflow failures.

## Release notes

Removed the requirement for the `CR_PAT` secret in the vulnerability check workflow.
