### PR TITLE
Skip if Docker image does not exist in vulnerability check workflow

### DIFF
--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -143,10 +143,20 @@ jobs:
         with:
           name: docker-images-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.target-ref }}
 
-      - name: Load Docker image
-        run: docker load -i ${{ matrix.image[1] }}.tar.gz
+      - name: Load Docker image if exists
+        id: load-image
+        run: |
+          IMAGE_TAR="${{ matrix.image[1] }}.tar.gz"
+          if [[ -f "$IMAGE_TAR" ]]; then
+            docker load -i "$IMAGE_TAR"
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "$IMAGE_TAR does not exist. Skipping this image."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run Trivy vulnerability scanner for ${{ matrix.image[0] }}
+        if: steps.load-image.outputs.skipped != 'true'
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ghcr.io/scalar-labs/${{ matrix.image[1] }}:${{ needs.build.outputs.version }}
@@ -157,7 +167,7 @@ jobs:
           timeout: '60m'
 
       - name: Post Trivy vulnerability check failure for ${{ matrix.image[0] }}
-        if: failure() && steps.slack-webhook.outputs.enabled == 'true'
+        if: failure() && steps.slack-webhook.outputs.enabled == 'true' && steps.load-image.outputs.skipped != 'true'
         uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

When we release Docker images in certain versions, there can be cases where some versions include a Docker image while others do not.

For example, the `scalardb-data-loader-cli` Docker image is released starting from version `3.16`, so earlier versions like `3.15` do not include the image. This currently causes errors in the vulnerability check workflow, such as the following:
https://github.com/scalar-labs/scalardb/actions/runs/16658774866

To handle such cases, this PR updates the vulnerability check workflow to skip the check if the Docker image does not exist.

## Related issues and/or PRs

- Updated the vulnerability check workflow to skip the check if the Docker image does not exist.

## Changes made

N/A

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
