### PR TITLE
Accept GPR_USERNAME and GPR_PASSWORD in vulnerability check workflow

### DIFF
--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -5,7 +5,6 @@ on:
     inputs:
       target-ref:
         description: 'Target ref (branch, tag, release) to scan'
-        required: true
         type: string
         default: 'main'
       find-latest-release:
@@ -23,12 +22,20 @@ on:
         type: string
         default: "./gradlew :common:properties -q | grep version: | awk '{print $2}'"
     secrets:
+      GPR_USERNAME:
+        description: 'Username for authenticating to GitHub Package Registry (GPR)'
+        required: false
+      GPR_PASSWORD:
+        description: 'Personal access token used to authenticate to GitHub Package Registry (GPR)'
+        required: false
       SLACK_SECURITY_WEBHOOK_URL:
         description: 'Slack webhook URL to post vulnerability check failure. If empty, the action will not post a message.'
         required: false
 
 env:
   TERM: dumb
+  GPR_USERNAME: ${{ secrets.GPR_USERNAME }}
+  GPR_PASSWORD: ${{ secrets.GPR_PASSWORD }}
 
 jobs:
   build:


### PR DESCRIPTION
## Description

After the change of https://github.com/scalar-labs/actions/pull/23, the Scheduled Vulnerability Check in ScalarDB Cluster is failing because `GPR_USERNAME` and `GPR_PASSWORD` environment variables were removed.

One of the failed workflow run is as follows:
https://github.com/scalar-labs/scalardb-cluster/actions/runs/16761326152

To address the issue, this PR updates the vulnerability check workflow to accept `GPR_USERNAME` and `GPR_PASSWORD`.

## Related issues and/or PRs

- https://github.com/scalar-labs/actions/pull/23

## Changes made

- Updated the vulnerability check workflow to accept `GPR_USERNAME` and `GPR_PASSWORD`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
