### PR TITLE
Use safe commit hash for trivy-action

### DIFF
--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -175,7 +175,10 @@ jobs:
 
       - name: Run Trivy vulnerability scanner for ${{ matrix.image[0] }}
         if: steps.load-image.outputs.skipped != 'true'
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        # To address the following security issue, we use the specific version for now. We might need to update the version in the future.
+        # Note that the release v0.35.0 is protected by GitHub's immutable releases feature.
+        # https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ghcr.io/scalar-labs/${{ matrix.image[1] }}:${{ needs.build.outputs.version }}
           format: 'table'

--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner for ${{ matrix.image[0] }}
         if: steps.load-image.outputs.skipped != 'true'
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.69.3
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ghcr.io/scalar-labs/${{ matrix.image[1] }}:${{ needs.build.outputs.version }}
           format: 'table'

--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner for ${{ matrix.image[0] }}
         if: steps.load-image.outputs.skipped != 'true'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.69.3
         with:
           image-ref: ghcr.io/scalar-labs/${{ matrix.image[1] }}:${{ needs.build.outputs.version }}
           format: 'table'


### PR DESCRIPTION
## Description

This PR changes the reference for trivy-action from the branch name to the full SHA to avoid supply chain attacks.

## Related issues and/or PRs

N/A

## Changes made

- Change the reference for trivy-action from `master` to the full SHA of `v0.69.3`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23
- https://diary.shift-js.info/trivy-compromise
