### PR TITLE
Add workflow to enforce `.mdx` file extensions in PRs

### DIFF
--- a/.github/workflows/validate-markdown-file-extensions-reusable.yml
+++ b/.github/workflows/validate-markdown-file-extensions-reusable.yml
@@ -1,0 +1,111 @@
+name: Validate Markdown File Extensions
+
+on:
+  workflow_call:
+    inputs:
+      docs-paths:
+        description: 'Comma-separated list of documentation paths to check (default: "docs/en-us/,docs/ja-jp/")'
+        required: false
+        type: string
+        default: "docs/en-us/,docs/ja-jp/"
+      components-path:
+        description: 'Path to components directory (default: "src/components/")'
+        required: false
+        type: string
+        default: "src/components/"
+
+jobs:
+  validate-mdx-extensions:
+    name: Check for .md files in docs locale folders and components
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCS_PATHS: ${{ inputs.docs-paths }}
+          COMPONENTS_PATH: ${{ inputs.components-path }}
+        run: |
+          # Get a list of the changed files from the PR, with fallback for local testing.
+          if [[ -n "${{ github.event.number }}" ]] && command -v gh >/dev/null 2>&1; then
+            # Running in GitHub Actions with PR context.
+            files=$(gh pr view ${{ github.event.number }} --json files --jq '.files[].path' 2>/dev/null || echo "")
+          else
+            # Fallback for local testing or when gh is not available.
+            # Compare current branch with main branch to get changed files.
+            files=$(git diff --name-only origin/main...HEAD 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
+          fi
+
+          # Convert comma-separated paths to regex pattern
+          docs_pattern=$(echo "$DOCS_PATHS" | sed 's/,/|/g' | sed 's/\//\\\//g')
+          components_pattern=$(echo "$COMPONENTS_PATH" | sed 's/\//\\\//g')
+
+          # Filter for .md files in specified paths
+          invalid_files=""
+          relevant_files=""
+          while IFS= read -r file; do
+            if [[ -n "$file" && ("$file" =~ ^($docs_pattern) || "$file" =~ ^$components_pattern) ]]; then
+              relevant_files="$relevant_files$file"$'\n'
+              if [[ "$file" =~ \.md$ ]]; then
+                invalid_files="$invalid_files$file"$'\n'
+              fi
+            fi
+          done <<< "$files"
+
+          # Remove trailing newlines.
+          invalid_files=$(echo "$invalid_files" | sed '/^$/d')
+          relevant_files=$(echo "$relevant_files" | sed '/^$/d')
+
+          # Set outputs.
+          echo "invalid_files<<EOF" >> $GITHUB_OUTPUT
+          echo "$invalid_files" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "relevant_files<<EOF" >> $GITHUB_OUTPUT
+          echo "$relevant_files" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          if [[ -n "$invalid_files" ]]; then
+            echo "has_invalid_files=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_invalid_files=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ -n "$relevant_files" ]]; then
+            echo "has_relevant_files=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_relevant_files=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate file extensions
+        if: steps.changed-files.outputs.has_invalid_files == 'true'
+        env:
+          INVALID_FILES: ${{ steps.changed-files.outputs.invalid_files }}
+          DOCS_PATHS: ${{ inputs.docs-paths }}
+          COMPONENTS_PATH: ${{ inputs.components-path }}
+        run: |
+          echo "❌ Found .md files that should use the .mdx extension:"
+          echo ""
+          echo "The following files have invalid extensions:"
+          echo "$INVALID_FILES" | while IFS= read -r file; do
+            echo "  • $file"
+          done
+          echo ""
+          echo "📝 In Docusaurus projects, files in these locations must use the .mdx extension:"
+          echo "   • $DOCS_PATHS (locale-specific documentation)"
+          echo "   • $COMPONENTS_PATH (React components and documentation)"
+          echo ""
+          echo "🔧 To fix this issue:"
+          echo "   1. Rename each .md file to .mdx."
+          echo "   2. Update any references to these files in other documents."
+          echo "   3. Ensure the file content is compatible with MDX format."
+          echo ""
+          echo "ℹ️ Files outside of these folders can remain as .md."
+
+          exit 1

--- a/.github/workflows/validate-markdown-file-extensions-reusable.yml
+++ b/.github/workflows/validate-markdown-file-extensions-reusable.yml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCS_PATHS: ${{ inputs.docs-paths }}
           COMPONENTS_PATH: ${{ inputs.components-path }}
         run: |
@@ -48,10 +48,8 @@ jobs:
 
           # Filter for .md files in specified paths
           invalid_files=""
-          relevant_files=""
           while IFS= read -r file; do
             if [[ -n "$file" && ("$file" =~ ^($docs_pattern) || "$file" =~ ^$components_pattern) ]]; then
-              relevant_files="$relevant_files$file"$'\n'
               if [[ "$file" =~ \.md$ ]]; then
                 invalid_files="$invalid_files$file"$'\n'
               fi
@@ -60,27 +58,16 @@ jobs:
 
           # Remove trailing newlines.
           invalid_files=$(echo "$invalid_files" | sed '/^$/d')
-          relevant_files=$(echo "$relevant_files" | sed '/^$/d')
 
           # Set outputs.
           echo "invalid_files<<EOF" >> $GITHUB_OUTPUT
           echo "$invalid_files" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-          echo "relevant_files<<EOF" >> $GITHUB_OUTPUT
-          echo "$relevant_files" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
           if [[ -n "$invalid_files" ]]; then
             echo "has_invalid_files=true" >> $GITHUB_OUTPUT
           else
             echo "has_invalid_files=false" >> $GITHUB_OUTPUT
-          fi
-
-          if [[ -n "$relevant_files" ]]; then
-            echo "has_relevant_files=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_relevant_files=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Validate file extensions

--- a/validate-markdown-file-extensions-script/README.md
+++ b/validate-markdown-file-extensions-script/README.md
@@ -1,0 +1,43 @@
+# Set Up Workflow for Validating Markdown File Extensions
+
+This workflow validates that Markdown files in Docusaurus projects use the correct file extensions:
+
+- Files in documentation locale folders (default: `docs/en-us/`, `docs/ja-jp/`) must use `.mdx` extension
+- Files in components directories (default: `src/components/`) must use `.mdx` extension
+
+## Why this matters
+
+Docusaurus requires `.mdx` extensions for files that may contain JSX components or need advanced MDX features. Inconsistent extensions can cause build failures and deployment issues.
+
+## Set up workflow
+
+The following instructions will guide you through setting up the workflow in your repository to ensure that all Markdown files have the correct extensions.
+
+### Step 1: Add the workflow file to your repository
+
+Copy the [**validate-markdown-file-extensions.yaml**](validate-markdown-file-extensions.yaml) file to your repository's `.github/workflows/` directory.
+
+> [!TIP]
+>
+> If your project structure differs from the defaults, you can customize the paths by uncommenting and modifying the `with` section:
+>
+> ```yaml
+> with:
+>   docs-paths: "your/docs/path/,another/docs/path/"
+>   components-path: "your/components/path/"
+
+### Step 2: Configure branch protection
+
+1. Navigate to your repository on GitHub.
+1. Select the **Settings** tab (requires admin access).
+1. Select the **Rulesets** in the left sidebar.
+1. Select **Add rule** or edit an existing rule.
+1. Under **Target branches**, add the necessary branches (for example, **main**, **3.\***, and **4.\***).
+1. Enable **Require status checks to pass**.
+
+### Step 3: Add the workflow as a required check
+
+1. In the search box under **Status checks that are required**, type **Check for .md files in docs locale folders and components**.
+1. Select it when it appears (it will show up after the first PR runs the workflow).
+1. Enable **"Do not allow bypassing the above settings" (prevents admin override)**.
+1. Select **Create** or **Save changes**.

--- a/validate-markdown-file-extensions-script/README.md
+++ b/validate-markdown-file-extensions-script/README.md
@@ -9,7 +9,7 @@ This workflow validates that Markdown files in Docusaurus projects use the corre
 
 Docusaurus requires `.mdx` extensions for files that may contain JSX components or need advanced MDX features. Inconsistent extensions can cause build failures and deployment issues.
 
-## Set up workflow
+## Set up the workflow
 
 The following instructions will guide you through setting up the workflow in your repository to ensure that all Markdown files have the correct extensions.
 
@@ -25,6 +25,7 @@ Copy the [**validate-markdown-file-extensions.yaml**](validate-markdown-file-ext
 > with:
 >   docs-paths: "your/docs/path/,another/docs/path/"
 >   components-path: "your/components/path/"
+> ```
 
 ### Step 2: Configure branch protection
 

--- a/validate-markdown-file-extensions-script/validate-markdown-file-extensions.yaml
+++ b/validate-markdown-file-extensions-script/validate-markdown-file-extensions.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   validate-mdx-extensions:
-    uses: scalar-labs/actions/.github/workflows/.github/workflows/validate-markdown-file-extensions-reusable.yml@main
+    uses: scalar-labs/actions/.github/workflows/validate-markdown-file-extensions-reusable.yml@main
     # Optional: customize the paths if they differ from defaults
     # with:
     #   docs-paths: "docs/en-us/,docs/ja-jp/"

--- a/validate-markdown-file-extensions-script/validate-markdown-file-extensions.yaml
+++ b/validate-markdown-file-extensions-script/validate-markdown-file-extensions.yaml
@@ -1,0 +1,17 @@
+name: Validate Markdown File Extensions
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "[0-9]+"
+      - "[0-9]+.[0-9]+"
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate-mdx-extensions:
+    uses: scalar-labs/actions/.github/workflows/.github/workflows/validate-markdown-file-extensions-reusable.yml@main
+    # Optional: customize the paths if they differ from defaults
+    # with:
+    #   docs-paths: "docs/en-us/,docs/ja-jp/"
+    #   components-path: "src/components/"


### PR DESCRIPTION
## Description

This PR introduces a new GitHub Actions workflow to enforce the use of the **.mdx** extension (instead of **.md**) for Markdown files in specific documentation and component directories:

- **docs/en-us/**
- **docs/ja-jp/**
- **src/components/**

For this workflow to work, a branch rule must be created and **Require status checks to pass** must be selected, with the workflow added in this PR. For instructions on how to set that up, see **Additional notes** at the end of this PR description.

## Related issues and/or PRs

- PRs for adding the workflow that calls the workflow based in the **actions** repository:
  - **docs-internal-scalardb:** https://github.com/scalar-labs/docs-internal-scalardb/pull/2319
  - **docs-internal-scalardl:** https://github.com/scalar-labs/docs-internal-scalardl/pull/914

## Changes made

* Created **.github/workflows/validate-markdown-file-extensions-reusable.yml** to automatically check pull requests for **.md** files in **docs/en-us/**, **docs/ja-jp/**, and **src/components/**, and fail the build if any are found, prompting contributors to use **.mdx** instead.
* Created **validate-markdown-file-extensions-script/validate-markdown-file-extensions.yaml**, which can be added to repositories to call the centralized **.github/workflows/validate-markdown-file-extensions-reusable.yml** workflow.
* Created **README.md**, which describes how to configure rulesets for branches in the repositories that use this workflow.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Created with help from Claude Sonnet 4.