### PR TITLE
Change runner and add configuration to skip backport PRs in Markdown extension-checking workflow

### DIFF
--- a/.github/workflows/validate-markdown-file-extensions-reusable.yml
+++ b/.github/workflows/validate-markdown-file-extensions-reusable.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   validate-mdx-extensions:
     name: Check for .md files in docs locale folders and components
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Checkout code

--- a/validate-markdown-file-extensions-script/validate-markdown-file-extensions.yaml
+++ b/validate-markdown-file-extensions-script/validate-markdown-file-extensions.yaml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   validate-mdx-extensions:
+    # Skip backport PRs (titles starting with "Backport to branch" and branch names that contain the "MAJOR.MINOR-pull-PR_NUMBER" pattern)
+    if: ${{ !(startsWith(github.event.pull_request.title, 'Backport to branch') && contains(github.head_ref, '-pull-')) }}
     uses: scalar-labs/actions/.github/workflows/validate-markdown-file-extensions-reusable.yml@main
     # Optional: customize the paths if they differ from defaults
     # with:


### PR DESCRIPTION
## Description

This PR updates the GitHub Actions workflow for validating Markdown file extensions by switching the runner for workflow efficiency and ensuring that validation checks are skipped for backport pull requests.

> [!NOTE]
>
> The changes here were also made in the commit https://github.com/scalar-labs/actions/pull/43/changes/bc7b4e2c3d291350f92d0a107d061476bcdaadd9 in PR #43. If we need to make changes to the backport function in this workflow, we should update it in #43 as well.

## Related issues and/or PRs

- #42 

## Changes made

* Changed the runner for the `validate-mdx-extensions` job in `.github/workflows/validate-markdown-file-extensions-reusable.yml` from `ubuntu-latest` to the lighter-weight `ubuntu-slim` to improve efficiency.
* Updated `validate-markdown-file-extensions.yaml` to skip the validation job for backport pull requests by adding a conditional check on the PR title and branch name.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A