### PR TITLE
Fix auto-translation workflow by switching Claude Code Action from `beta` to `main` branch and specifying model

### DIFF
--- a/.github/workflows/auto-translate-docs-reusable.yml
+++ b/.github/workflows/auto-translate-docs-reusable.yml
@@ -37,7 +37,8 @@ jobs:
           gh auth setup-git
 
       - name: Auto-translate documentation to Japanese
-        uses: anthropics/claude-code-action@main
+        # Pin to immutable SHA (current commit behind v1) to reduce supply-chain risk.
+        uses: anthropics/claude-code-action@30544b674398ee15c84819bd87caf8a87e8c7b55
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-sonnet-4-6"

--- a/.github/workflows/auto-translate-docs-reusable.yml
+++ b/.github/workflows/auto-translate-docs-reusable.yml
@@ -37,7 +37,7 @@ jobs:
           gh auth setup-git
 
       - name: Auto-translate documentation to Japanese
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-sonnet-4-6"

--- a/.github/workflows/auto-translate-docs-reusable.yml
+++ b/.github/workflows/auto-translate-docs-reusable.yml
@@ -40,6 +40,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model claude-sonnet-4-6"
           trigger_phrase: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && '' || 'auto-translate' }}
           mode: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && 'agent' || 'tag' }}
           direct_prompt: |


### PR DESCRIPTION
## Description

This PR fixes an issue where the GitHub Actions workflow for auto-translating documentation encounters an error because of the default Claude model that is being used on the `@beta` branch of the [Claude Code Action](https://github.com/anthropics/claude-code-action/). To address this, this PR changes the action being used from the `@beta` branch to the latest SHA for v1 and specifies the use of a particular Claude model (`claude-sonnet-4-6`) for the translation action.

> [!IMPORTANT]
>
> - Anthropic deprecated the default model (`claude-sonnet-4-20250514`) used on the `beta` branch of [Claude Code Action](https://github.com/anthropics/claude-code-action/) on June 15, 2026. Reference: [2026-04-14: Claude Sonnet 4 and Claude Opus 4 models](https://platform.claude.com/docs/en/about-claude/model-deprecations#2026-04-14-claude-sonnet-4-and-claude-opus-4-models)
> - I pinned the action to the latest SHA for v1 because `anthropics/claude-code-action` doesn't seem to use branches for versions.

## Related issues and/or PRs

N/A

## Changes made

* Changed which action is used from `anthropics/claude-code-action@beta` to `anthropics/claude-code-action@30544b674398ee15c84819bd87caf8a87e8c7b55`, which is currently the latest SHA for v1.
* Updated the `claude-code-action` step in `.github/workflows/auto-translate-docs-reusable.yml` to explicitly use the `claude-sonnet-4-6` model for translations.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A