### PR TITLE
Fix beta-only configs in Claude Code Action for docs translation workflow

### DIFF
--- a/.github/workflows/auto-translate-docs-reusable.yml
+++ b/.github/workflows/auto-translate-docs-reusable.yml
@@ -45,7 +45,6 @@ jobs:
             --model claude-sonnet-4-6
             --allowedTools "View,Edit,Glob,Grep,Bash(git:*),Bash(mkdir:*),Bash(gh:*),Bash(cat:*)"
           trigger_phrase: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && '' || 'auto-translate' }}
-          mode: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && 'agent' || 'tag' }}
           prompt: |
             A documentation PR has been merged. Please translate any English documentation changes to Japanese and create a new PR.
 

--- a/.github/workflows/auto-translate-docs-reusable.yml
+++ b/.github/workflows/auto-translate-docs-reusable.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   auto-translate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Only run if PR was merged (not just closed) OR if the workflow was manually triggered OR if the workflow was called from another workflow
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
     steps:

--- a/.github/workflows/auto-translate-docs-reusable.yml
+++ b/.github/workflows/auto-translate-docs-reusable.yml
@@ -41,10 +41,12 @@ jobs:
         uses: anthropics/claude-code-action@30544b674398ee15c84819bd87caf8a87e8c7b55
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6"
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "View,Edit,Glob,Grep,Bash(git:*),Bash(mkdir:*),Bash(gh:*),Bash(cat:*)"
           trigger_phrase: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && '' || 'auto-translate' }}
           mode: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && 'agent' || 'tag' }}
-          direct_prompt: |
+          prompt: |
             A documentation PR has been merged. Please translate any English documentation changes to Japanese and create a new PR.
 
             ## Task
@@ -117,8 +119,6 @@ jobs:
             IMPORTANT: Make sure to authenticate with GitHub CLI first by running the gh auth commands that are available.
 
             Please analyze the merged PR, create the translations, and submit a new PR automatically.
-          allowed_tools: "View,Edit,Glob,Grep,Bash(git:*),Bash(mkdir:*),Bash(gh:*),Bash(cat:*)"
-          timeout_minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR updates the `.github/workflows/auto-translate-docs-reusable.yml` workflow to fix how inputs are handled. Some inputs that existed in the `beta` version of the [Claude Code Action](https://github.com/anthropics/claude-code-action) don't exist in the non-`beta` version, according to https://github.com/anthropics/claude-code-action/blob/360be9c8fc5d80cb33661e0ffd33dcef4c7155aa/docs/configuration.md#migration-from-deprecated-inputs.

## Related issues and/or PRs

Changed from changed to a supported language model and moved from beta to v1 in the following PR:

- #49

However, there were backward incompatible changes with the beta version and v1, which are addressed in this PR.

## Changes made

* The `claude_args` input now uses a multiline format and explicitly specifies `--allowedTools` to control which tools Claude can use during execution.
* The `prompt` input replaces `direct_prompt` for clarity and consistency with the latest action interface.
* The previously separate `allowed_tools` key is removed, centralizing allowed tool configuration under `claude_args`.
* The `timeout_minutes` setting is removed, possibly to use the default or manage timeouts elsewhere.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A