### PR TITLE
Increase Claude Code auto-translate job timeout from 10 minutes to 30 minutes

### DIFF
--- a/.github/workflows/auto-translate-docs-reusable.yml
+++ b/.github/workflows/auto-translate-docs-reusable.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   auto-translate:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     # Only run if PR was merged (not just closed) OR if the workflow was manually triggered OR if the workflow was called from another workflow
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
     steps:


### PR DESCRIPTION
## Description

This PR increases the job timeout from 10 minutes to 30 minutes in `auto-translate-docs-reusable.yml` workflow. This change allows more time for the auto-translate process to complete, reducing the risk of timeouts for longer-running jobs.

Before switching from the Claude Code Actions beta, 10 minutes was enough time to produce a translations. However, it seems that more content/context needs to be processed for translations to finish, maybe because the previous model (Sonnet 4) was faster but not as good in terms of quality.

## Related issues and/or PRs

See the following failed action for an example of a translation job failing: https://github.com/scalar-labs/docs-internal-scalardb/actions/runs/28076684647/job/83122293391

## Changes made

- Changed `timeout-minutes` from `10` to `30`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A