### PR TITLE
Add working-directory input to the reusable vuln-check workflow

### DIFF
--- a/.github/workflows/vuln-check-reusable.yaml
+++ b/.github/workflows/vuln-check-reusable.yaml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: '8'
+      working-directory:
+        description: 'Directory to run the Gradle build and version command in. Defaults to the repository root.'
+        required: false
+        type: string
+        default: '.'
     secrets:
       GPR_USERNAME:
         description: 'Username for authenticating to GitHub Package Registry (GPR)'
@@ -101,10 +106,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Docker build
+        working-directory: ${{ inputs.working-directory }}
         run: ./gradlew docker
 
       - name: Set version
         id: version
+        working-directory: ${{ inputs.working-directory }}
         run: |
           VERSION=$(${{ inputs.version-command }})
           echo "version=${VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

This PR adds a `working-directory` input to the reusable vulnerability-check workflow so repositories whose Gradle project lives in a subdirectory rather than the repository root can run the Docker build and version command there. It defaults to `.`, so every existing caller is unaffected.

## Related issues and/or PRs

N/A

## Changes made

- Add a `working-directory` input (default `.`) to `vuln-check-reusable.yaml`.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
