### PR TITLE
Use ubuntu-slim runners for lightweight GitHub Actions jobs

### DIFF
--- a/.github/workflows/assign-dependabot-pr-reviewers.yaml
+++ b/.github/workflows/assign-dependabot-pr-reviewers.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   assign-reviewer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.actor == 'dependabot[bot]'
 
     steps:

--- a/.github/workflows/auto-pr-reusable.yaml
+++ b/.github/workflows/auto-pr-reusable.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   create_backport_pull_requests:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       GH_TOKEN: ${{ secrets.GH_PR_PAT }}
       # Escape the PR title. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable for details

--- a/auto-pr-script/conv_proj_version_to_branch
+++ b/auto-pr-script/conv_proj_version_to_branch
@@ -1,34 +1,59 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-require "set"
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
 
-default_branch = ARGV.shift
-versions = ARGV
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 default_branch [version...]"
+    exit 1
+fi
 
-versions.inject(Set.new) {|acc, v|
-  major_version, minor_version, patch_version = v.strip.split(".")
+default_branch=$1
+shift
 
-  if patch_version == "0"
-    if minor_version == "0"
-      # e.g. project: "ScalarDB 4.0.0" -> branch: "master"
-      #
-      # This GitHub project corresponds to `main`/`master` branch.
-      acc << default_branch
+branches=()
+
+for version in "$@"; do
+    # Trim the surrounding whitespace.
+    read -r version <<< "$version"
+
+    # The trailing `_` absorbs any extra dot-separated fields so that
+    # `patch_version` never swallows them (e.g. "3.7.0.2" -> patch_version="0").
+    IFS=. read -r major_version minor_version patch_version _ <<< "$version"
+
+    if [[ $patch_version == "0" ]]; then
+        if [[ $minor_version == "0" ]]; then
+            # e.g. project: "ScalarDB 4.0.0" -> branch: "master"
+            #
+            # This GitHub project corresponds to `main`/`master` branch.
+            branch=$default_branch
+        else
+            # e.g. project: "ScalarDB 3.8.0" -> branch: "3"
+            #
+            # This GitHub project corresponds to a support branch.
+            branch=$major_version
+        fi
     else
-      # e.g. project: "ScalarDB 3.8.0" -> branch: "3"
-      #
-      # This GitHub project corresponds to a support branch.
-      acc << major_version
-    end
-  else
-    # e.g. project: "ScalarDB 3.7.1" -> branch: "3.7"
-    #
-    # This GitHub project corresponds to a release branch.
-    acc << "#{major_version}.#{minor_version}"
-  end
+        # e.g. project: "ScalarDB 3.7.1" -> branch: "3.7"
+        #
+        # This GitHub project corresponds to a release branch.
+        branch="$major_version.$minor_version"
+    fi
 
-  acc
-}.each {|branch|
-  puts branch
-}
+    # Emit each branch only once, keeping the order of its first appearance.
+    is_duplicate=''
+    for known_branch in "${branches[@]}"; do
+        if [[ $known_branch == "$branch" ]]; then
+            is_duplicate='true'
+            break
+        fi
+    done
+    if [[ -n $is_duplicate ]]; then
+        continue
+    fi
 
+    branches+=("$branch")
+done
+
+for branch in "${branches[@]}"; do
+    echo "$branch"
+done


### PR DESCRIPTION
## Description

To reduce GitHub Actions running costs, we switch lightweight processing actions to a single-core runner `ubuntu-slim` instead of the currently used two-core runner `ubuntu-latest`; `ubuntu-slim` costs 0.002$ per minute vs `ubuntu-latest` 0.006$. 

## Related issues and/or PRs

N/A

## Changes made

- Switched `assign-dependabot-pr-reviewers.yaml` to `ubuntu-slim`. Its single step calls `gh pr edit`, and the GitHub CLI is preinstalled.
- Switched `auto-pr-reusable.yaml` to `ubuntu-slim`, and converts a Ruby script to Bash because this language is not available out of the box on this runner.

### Workflows intentionally left on `ubuntu-latest`

| Workflow | Why it cannot move |
| --- | --- |
| `vuln-check-reusable.yaml` | Both jobs need a Docker **daemon** for `./gradlew docker` and `docker save`/`docker load`; `ubuntu-slim` ships only the Docker client and runs unprivileged. It also needs Java/Gradle and the Ruby `vuln-check-script/find_latest_release`. |
| `auto-translate-docs-reusable.yml` | The maximum duration of a job on `ubuntu-slim` runner is 15 min but this action might take longer than that (it currently sets `timeout-minutes: 30`). |



## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
